### PR TITLE
Jammy/lts/5.15.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,8 +28,6 @@ steps:
     files:
     - "dist/artifacts/*"
   when:
-    instance:
-    - drone-publish.rancher.io
     ref:
     - refs/head/master
     - refs/tags/*
@@ -71,8 +69,6 @@ steps:
     files:
     - "dist/artifacts/*"
   when:
-    instance:
-    - drone-publish.rancher.io
     ref:
     - refs/head/master
     - refs/tags/*

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -18,10 +18,6 @@ RUN set -x \
 
 FROM ${BUILD}
 ARG DOWNLOADS
-# Wireguard support, included in Linux in 5.6+
-ARG WG_URL="https://git.zx2c4.com"
-ARG WG_REPO="wireguard-linux-compat"
-ARG WG_TAG=v1.0.20200413
 COPY --from=ubuntu ${DOWNLOADS}/ ${DOWNLOADS}/
 RUN apt-get --assume-yes update \
  && apt-get --assume-yes install --no-install-recommends --upgrade \
@@ -69,9 +65,6 @@ WORKDIR ${DAPPER_SOURCE}
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 ENV DOWNLOADS ${DOWNLOADS}
-ENV WG_URL=${WG_URL}
-ENV WG_REPO=${WG_REPO}
-ENV WG_TAG=${WG_TAG}
 
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,10 +1,11 @@
-ARG APT_GCC=library/gcc:9.2
-
-FROM library/ubuntu:bionic AS bionic
+ARG BUILD=library/buildpack-deps:jammy
+ARG UBUNTU=library/ubuntu:jammy
 ARG DOWNLOADS=/usr/src/downloads
-ARG LINUX_FIRMWARE=linux-firmware=1.173.18
-ARG LINUX_SOURCE=linux-source-5.0.0=5.0.0-47.51~18.04.1
 
+FROM ${UBUNTU} AS ubuntu
+ARG DOWNLOADS
+ARG LINUX_FIRMWARE=linux-firmware=20220329.git681281e4-0ubuntu3.4
+ARG LINUX_SOURCE=linux-source-5.15.0=5.15.0-46.49
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -x \
  && apt-get --assume-yes update \
@@ -15,32 +16,41 @@ RUN set -x \
  && mv -vf linux-firmware* ${DOWNLOADS}/ubuntu-firmware.deb \
  && mv -vf linux-source* ${DOWNLOADS}/ubuntu-kernel.deb
 
-FROM ${APT_GCC}
-ARG DOWNLOADS=/usr/src/downloads
+FROM ${BUILD}
+ARG DOWNLOADS
 # Wireguard support, included in Linux in 5.6+
 ARG WG_URL="https://git.zx2c4.com"
 ARG WG_REPO="wireguard-linux-compat"
 ARG WG_TAG=v1.0.20200413
-COPY --from=bionic ${DOWNLOADS}/ ${DOWNLOADS}/
-RUN apt-get update \
- && apt-get install -y \
-    kernel-wedge \
-    libncurses-dev \
-    fakeroot \
-    cpio \
-    bison \
-    flex \
-    ccache \
-    vim \
-    gnupg2 \
-    locales \
+COPY --from=ubuntu ${DOWNLOADS}/ ${DOWNLOADS}/
+RUN apt-get --assume-yes update \
+ && apt-get --assume-yes install --no-install-recommends --upgrade \
     bc \
-    kmod \
-    libelf-dev \
-    rsync \
+    bison \
+    ccache \
+    cpio \
+    dkms \
+    dwarves \
+    fakeroot \
+    flex \
     gawk  \
+    gcc-9 \
+    gnupg2 \
+    kernel-wedge \
+    kmod \
+    less \
+    libelf-dev \
+    libiberty-dev \
+    liblz4-tool \
+    libncurses-dev \
+    libpci-dev \
+    libssl-dev \
     libudev-dev \
-    pciutils-dev \
+    linux-libc-dev \
+    locales \
+    rsync \
+    vim \
+    zstd \
  && rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ########## Dapper Configuration #####################
@@ -50,7 +60,9 @@ ENV DAPPER_DOCKER_SOCKET true
 ENV DAPPER_SOURCE /source
 ENV DAPPER_OUTPUT ./dist ./build
 ENV DAPPER_RUN_ARGS --privileged
-ENV SHELL /bin/bash
+ENV EDITOR=vim \
+    PAGER=less \
+    SHELL=/bin/bash
 WORKDIR ${DAPPER_SOURCE}
 
 ########## General Configuration #####################

--- a/patches/aaeon-iwmi-wdt.patch
+++ b/patches/aaeon-iwmi-wdt.patch
@@ -1,0 +1,13 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.aaeon-iwmi-wdt/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
++++ kernel.aaeon-iwmi-wdt/debian.master/config/annotations	2022-08-13 01:21:29.477633005 +0000
+@@ -10485,7 +10485,7 @@
+ CONFIG_SBC_EPX_C3_WATCHDOG
+ CONFIG_INTEL_MEI_WDT                            policy<{'amd64': 'm'}>
+ CONFIG_NI903X_WDT                               policy<{'amd64': 'm'}>
+ CONFIG_NIC7018_WDT                              policy<{'amd64': 'm'}>
+-CONFIG_AAEON_IWMI_WDT                           policy<{'amd64': 'm'}>
++CONFIG_AAEON_IWMI_WDT                           policy<{'amd64': '-'}>
+ CONFIG_BCM2835_WDT                              policy<{'arm64': 'm'}>
+ CONFIG_BCM7038_WDT                              policy<{'arm64': 'm'}>
+ CONFIG_MEN_A21_WDT                              policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm', 's390x': 'm'}>

--- a/patches/apparmor.patch
+++ b/patches/apparmor.patch
@@ -1,0 +1,26 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.apparmor/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-12 12:20:47.401479000 +0000
++++ kernel.apparmor/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
+@@ -13994,7 +13994,7 @@
+ CONFIG_HARDENED_USERCOPY_FALLBACK
+ CONFIG_HARDENED_USERCOPY_PAGESPAN               policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 's390x': 'n'}>
+ CONFIG_FORTIFY_SOURCE                           policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+ CONFIG_STATIC_USERMODEHELPER                    policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 's390x': 'n'}>
+-CONFIG_LSM                                      policy<{'amd64': '"landlock,lockdown,yama,integrity,apparmor"', 'arm64': '"landlock,lockdown,yama,integrity,apparmor"', 'armhf': '"landlock,lockdown,yama,integrity,apparmor"', 'ppc64el': '"landlock,lockdown,yama,integrity,apparmor"', 's390x': '"landlock,lockdown,yama,integrity,apparmor"'}>
++CONFIG_LSM                                      policy<{'amd64': '"landlock,lockdown,yama,integrity"', 'arm64': '"landlock,lockdown,yama,integrity"', 'armhf': '"landlock,lockdown,yama,integrity"', 'ppc64el': '"landlock,lockdown,yama,integrity"', 's390x': '"landlock,lockdown,yama,integrity"'}>
+ #
+ CONFIG_SECURITY_DMESG_RESTRICT                  mark<ENFORCED>
+ CONFIG_LSM                                      mark<ENFORCED>
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.apparmor/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2022-08-12 12:21:12.393479012 +0000
++++ kernel.apparmor/debian.master/config/config.common.ubuntu	2022-08-04 17:16:56.000000000 +0000
+@@ -5802,7 +5803,7 @@
+ CONFIG_LPARCFG=y
+ # CONFIG_LP_CONSOLE is not set
+ CONFIG_LRU_CACHE=m
+ CONFIG_LSI_ET1011C_PHY=m
+-CONFIG_LSM="landlock,lockdown,yama,integrity,apparmor"
++CONFIG_LSM="landlock,lockdown,yama,integrity"
+ CONFIG_LSM_MMAP_MIN_ADDR=0
+ CONFIG_LS_EXTIRQ=y
+ CONFIG_LS_SCFG_MSI=y

--- a/patches/bpfilter-umh.patch
+++ b/patches/bpfilter-umh.patch
@@ -1,12 +1,26 @@
-diff -urbB kernel.unpatched/debian.hwe/config/config.common.ubuntu kernel/debian.hwe/config/config.common.ubuntu
---- kernel.unpatched/debian.hwe/config/config.common.ubuntu	2019-09-30 22:23:05.000000000 +0000
-+++ kernel/debian.hwe/config/config.common.ubuntu	2019-10-15 01:24:35.804607723 +0000
-@@ -1121,7 +1121,7 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.bpfilter-umh/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-12 12:20:47.401479000 +0000
++++ kernel.bpfilter-umh/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
+@@ -13034,7 +13034,7 @@
+ CONFIG_NET_SWITCHDEV
+
+ # Menu: Networking support >> Networking options >> TCP/IP networking >> BPF based packet filtering framework (BPFILTER)
+ CONFIG_BPFILTER                                 policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+-CONFIG_BPFILTER_UMH                             policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm', 's390x': 'm'}>
++CONFIG_BPFILTER_UMH                             policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+
+ # Menu: Networking support >> Networking options >> TCP/IP networking >> Distributed Switch Architecture
+ CONFIG_NET_DSA                                  policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm', 's390x': 'n'}>
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.bpfilter-umh/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2022-08-12 12:21:12.393479012 +0000
++++ kernel.bpfilter-umh/debian.master/config/config.common.ubuntu	2022-08-04 17:16:56.000000000 +0000
+@@ -1275,7 +1275,7 @@
  CONFIG_BOOT_PRINTK_DELAY=y
+ CONFIG_BOUNCE=y
  CONFIG_BPF=y
  CONFIG_BPFILTER=y
 -CONFIG_BPFILTER_UMH=m
 +CONFIG_BPFILTER_UMH=y
  CONFIG_BPF_EVENTS=y
  CONFIG_BPF_JIT=y
- CONFIG_BPF_KPROBE_OVERRIDE=y
+ CONFIG_BPF_JIT_ALWAYS_ON=y

--- a/patches/dwarf.patch
+++ b/patches/dwarf.patch
@@ -1,0 +1,28 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.dwarf/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-12 12:20:47.401479000 +0000
++++ kernel.dwarf/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
+@@ -11730,8 +11730,8 @@
+ CONFIG_DEBUG_INFO_SPLIT
+ CONFIG_DEBUG_INFO_BTF                           flag<REVIEW> note<Needs newer pahole for armhf>
+
+ # Menu: Kernel hacking >> Compile-time checks and compiler options >> Compile the kernel with debug info >> DWARF version
+-CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT       policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 's390x': 'n'}>
+-CONFIG_DEBUG_INFO_DWARF5                        policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
++CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT       policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
++CONFIG_DEBUG_INFO_DWARF5                        policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 's390x': 'n'}>
+
+ # Menu: Kernel hacking >> Debug Oops, Lockups and Hangs
+ CONFIG_PANIC_ON_OOPS                            policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 's390x': 'n'}>
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.dwarf/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2022-08-12 12:20:47.401479000 +0000
++++ kernel.dwarf/debian.master/config/config.common.ubuntu	2022-08-04 17:16:56.000000000 +0000
+@@ -2592,7 +2592,7 @@
+ CONFIG_DEBUG_INFO=y
+ CONFIG_DEBUG_INFO_BTF_MODULES=y
+ # CONFIG_DEBUG_INFO_COMPRESSED is not set
+ # CONFIG_DEBUG_INFO_DWARF4 is not set
+-CONFIG_DEBUG_INFO_DWARF5=y
++CONFIG_DEBUG_INFO_DWARF5=n
+ # CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT is not set
+ # CONFIG_DEBUG_INFO_REDUCED is not set
+ # CONFIG_DEBUG_INFO_SPLIT is not set

--- a/patches/gpio-aaeon.patch
+++ b/patches/gpio-aaeon.patch
@@ -1,0 +1,13 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.gpio-aaeon/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
++++ kernel.gpio-aaeon/debian.master/config/annotations	2022-08-13 01:21:29.477633005 +0000
+@@ -1962,7 +1962,7 @@
+ CONFIG_GPIO_MSC313
+ CONFIG_GPIO_EM                                  note<h/w not encounted>
+
+ # Menu: Device Drivers >> GPIO Support >> PCI GPIO expanders
+-CONFIG_GPIO_AAEON                               policy<{'amd64': 'm'}>
++CONFIG_GPIO_AAEON                               policy<{'amd64': '-'}>
+ CONFIG_GPIO_AMD8111                             policy<{'amd64': 'm'}>
+ CONFIG_GPIO_BT8XX                               policy<{'s390x': 'm'}>
+ CONFIG_GPIO_MLXBF                               policy<{'arm64': 'm'}>

--- a/patches/ikconfig-proc.patch
+++ b/patches/ikconfig-proc.patch
@@ -1,13 +1,27 @@
-diff -urbB kernel.unpatched/debian.hwe/config/config.common.ubuntu kernel/debian.hwe/config/config.common.ubuntu
---- kernel.unpatched/debian.hwe/config/config.common.ubuntu	2020-01-14 08:32:18.000000000 -0700
-+++ kernel/debian.hwe/config/config.common.ubuntu	2020-01-28 17:22:23.636051777 -0700
-@@ -4127,7 +4127,8 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.ikconfig/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-12 12:20:47.401479000 +0000
++++ kernel.ikconfig/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
+@@ -11380,7 +11380,7 @@
+ CONFIG_USELIB
+ CONFIG_AUDIT                                    policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+ CONFIG_SCHED_CORE                               policy<{'amd64': 'y', 'arm64': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+ CONFIG_CPU_ISOLATION                            policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+-CONFIG_IKCONFIG                                 policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n', 's390x': 'n'}>
++CONFIG_IKCONFIG                                 policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm', 's390x': 'm'}>
+ CONFIG_IKHEADERS                                policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm', 's390x': 'm'}>
+ CONFIG_LOG_BUF_SHIFT                            policy<{'amd64': '18', 'arm64': '18', 'armhf': '17', 'ppc64el': '18', 's390x': '18'}>
+ CONFIG_LOG_CPU_MAX_BUF_SHIFT                    policy<{'amd64': '12', 'arm64': '12', 'armhf': '12', 'ppc64el': '12', 's390x': '12'}>
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.ikconfig/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2022-08-12 12:21:12.393479012 +0000
++++ kernel.ikconfig/debian.master/config/config.common.ubuntu	2022-08-04 17:16:56.000000000 +0000
+@@ -4752,7 +4752,8 @@
+ CONFIG_IIO_TIGHTLOOP_TRIGGER=m
  CONFIG_IIO_TRIGGER=y
  CONFIG_IIO_TRIGGERED_BUFFER=m
  CONFIG_IIO_TRIGGERED_EVENT=m
 -# CONFIG_IKCONFIG is not set
 +CONFIG_IKCONFIG=m
 +CONFIG_IKCONFIG_PROC=y
+ CONFIG_IKHEADERS=m
  CONFIG_IMA=y
  CONFIG_IMA_APPRAISE=y
- CONFIG_IMA_APPRAISE_BOOTPARAM=y

--- a/patches/leds-aaeon.patch
+++ b/patches/leds-aaeon.patch
@@ -1,0 +1,13 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.leds-aaeon/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
++++ kernel.leds-aaeon/debian.master/config/annotations	2022-08-13 01:21:29.477633005 +0000
+@@ -4213,7 +4213,7 @@
+ CONFIG_USERIO
+
+ # Menu: Device Drivers >> LED Support
+ CONFIG_NEW_LEDS                                 policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'n'}>
+-CONFIG_LEDS_AAEON                               policy<{'amd64': 'm'}>
++CONFIG_LEDS_AAEON                               policy<{'amd64': '-'}>
+
+ # Menu: Device Drivers >> LED Support >> LED Class Support
+ CONFIG_LEDS_CLASS                               policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y'}>

--- a/patches/mfd-aaeon.patch
+++ b/patches/mfd-aaeon.patch
@@ -1,0 +1,13 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.mfd-aaeon/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
++++ kernel.mfd-aaeon/debian.master/config/annotations	2022-08-13 01:21:29.477633005 +0000
+@@ -4977,7 +4977,7 @@
+ CONFIG_MFD_ATC260X_I2C
+ CONFIG_MFD_KHADAS_MCU                           policy<{'arm64': 'm', 'armhf': 'm'}>
+ CONFIG_MFD_ACER_A500_EC                         policy<{'armhf-generic': 'm'}>
+ CONFIG_MFD_QCOM_PM8008                          policy<{'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm'}>
+-CONFIG_MFD_AAEON                                policy<{'amd64': 'm'}>
++CONFIG_MFD_AAEON                                policy<{'amd64': '-'}>
+ CONFIG_MFD_VEXPRESS_SYSREG                      policy<{'arm64': 'y', 'armhf': 'y'}>
+ CONFIG_RAVE_SP_CORE                             policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm', 's390x': 'n'}>
+ CONFIG_MFD_INTEL_M10_BMC                        policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm'}>

--- a/patches/sensors-aaeon.patch
+++ b/patches/sensors-aaeon.patch
@@ -1,0 +1,13 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.sensors-aaeon/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2022-08-04 17:16:56.000000000 +0000
++++ kernel.sensors-aaeon/debian.master/config/annotations	2022-08-13 01:21:29.477633005 +0000
+@@ -2856,7 +2856,7 @@
+ CONFIG_STM_SOURCE_FTRACE
+ # Menu: Device Drivers >> Hardware Monitoring support
+ CONFIG_HWMON                                    policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'ppc64el': 'y', 's390x': 'n'}>
+ CONFIG_HWMON_DEBUG_CHIP                         policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'ppc64el': 'n'}>
+-CONFIG_SENSORS_AAEON                            policy<{'amd64': 'm'}>
++CONFIG_SENSORS_AAEON                            policy<{'amd64': '-'}>
+ CONFIG_SENSORS_ABITUGURU                        policy<{'amd64': 'm'}>
+ CONFIG_SENSORS_ABITUGURU3                       policy<{'amd64': 'm'}>
+ CONFIG_SENSORS_AD7314                           policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm'}>

--- a/scripts/build
+++ b/scripts/build
@@ -8,16 +8,19 @@ KERNEL_DIR=build/kernel
 
 # some hacking
 mkdir -p ${KERNEL_DIR}/debian/stamps
-chmod -R +x ${KERNEL_DIR}/debian/scripts
+chmod a+x ${KERNEL_DIR}/debian*/scripts/*
+chmod a+x ${KERNEL_DIR}/debian*/scripts/misc/*
 
 # kernel
 pushd ${KERNEL_DIR}
+unset -v ARCH KERNEL_DIR
 debian/rules clean
 # see https://wiki.ubuntu.com/KernelTeam/KernelMaintenance#Overriding_module_check_failures
-for abi in $(find . -mindepth 1 -maxdepth 2 -type d -name abi); do
-    for ver in $abi/5.*; do
-        echo bpfilter > $ver/modules.ignore
-    done
-done
-debian/rules binary-headers binary-generic do_zfs=false do_dkms_nvidia=false #skipmodule=true
+debian/rules binary-headers binary-generic \
+    do_zfs=false \
+    do_dkms_nvidia=false \
+    do_dkms_nvidia_server=false \
+	skipabi=true \
+	skipmodule=true \
+	skipretpoline=true
 popd

--- a/scripts/package
+++ b/scripts/package
@@ -11,16 +11,16 @@ GENERIC_EXTRA_DIR=dist/generic/modules-extra
 mkdir -p ${GENERIC_HEADERS_DIR} ${GENERIC_MAIN_DIR} ${GENERIC_EXTRA_DIR}
 
 # headers
-dpkg-deb -x build/linux-headers-5.0.*.deb ${GENERIC_HEADERS_DIR}/
-dpkg-deb -x build/linux-hwe-5.0-headers-*.deb ${GENERIC_HEADERS_DIR}/
+sh -xc "dpkg-deb -x build/linux-headers-5.*generic*.deb ${GENERIC_HEADERS_DIR}/"
+sh -xc "dpkg-deb -x build/linux-headers-5.*all.deb ${GENERIC_HEADERS_DIR}/"
 
 # main modules and vmlinuz and firmware
-dpkg-deb -x build/linux-image-unsigned-5.0.*.deb ${GENERIC_MAIN_DIR}
-dpkg-deb -x build/linux-modules-5.0*.deb ${GENERIC_MAIN_DIR}
-dpkg-deb -x ${DOWNLOADS}/ubuntu-firmware.deb ${GENERIC_MAIN_DIR}
+sh -xc "dpkg-deb -x build/linux-image-unsigned-5.*.deb ${GENERIC_MAIN_DIR}"
+sh -xc "dpkg-deb -x build/linux-modules-5.*.deb ${GENERIC_MAIN_DIR}"
+sh -xc "dpkg-deb -x ${DOWNLOADS}/ubuntu-firmware.deb ${GENERIC_MAIN_DIR}"
 
 # extra modules
-dpkg-deb -x build/linux-modules-extra-5.0*.deb ${GENERIC_EXTRA_DIR}
+sh -xc "dpkg-deb -x build/linux-modules-extra-5.*.deb ${GENERIC_EXTRA_DIR}"
 
 # package artifacts
 mkdir -p dist/artifacts

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -4,6 +4,8 @@ set -e
 source $(dirname $0)/version
 cd $(dirname $0)/..
 
+set -x
+
 mkdir -p ${DOWNLOADS}/kernel ${DOWNLOADS}/firmware
 
 # kernel
@@ -18,19 +20,13 @@ tar xf ${DOWNLOADS}/kernel/usr/src/linux-source-*/linux-source*.tar.bz2 -C ./bui
 #rsync -a ${DOWNLOADS}/firmware/lib/firmware/* ./build/firmware/
 
 # patches
+if [ -n "${NOPATCHES}" ]; then
+    exit 0
+fi
 PATCHES_DIR=$(pwd)/patches
 pushd build/kernel
-for p in $(find ${PATCHES_DIR} -name "*.patch"); do
+for p in `find ${PATCHES_DIR} -name "*.patch"`; do
     echo "applying $p"
     patch -p1 -i $p
 done
-
-# https://www.wireguard.com/compilation/
-WG_DIR=$(mktemp -d)
-git clone "${WG_URL}/${WG_REPO}" -b "$WG_TAG" "$WG_DIR"
-"${WG_DIR}/kernel-tree-scripts/create-patch.sh" | patch -p1
-CONFIG="debian.hwe/config/config.common.ubuntu"
-echo CONFIG_WIREGUARD=m >>$CONFIG
-echo CONFIG_WIREGUARD_DEBUG=n >>$CONFIG
-
 popd


### PR DESCRIPTION
- Ubuntu Jammy LTS Kernel 5.15.0-46.49
- Linux Firmware 20220329.git681281e4-0ubuntu3.4